### PR TITLE
Config class

### DIFF
--- a/master/core/framework/framework.config.php
+++ b/master/core/framework/framework.config.php
@@ -40,7 +40,7 @@ class Config
     {
         if (!$this->existsInCache($path)) {
             list($file, $reference) = explode('.', $path, 1);
-            $this->config[$file] = (require 'config/' . $file);
+            $this->config[$file] = (require 'config/' . $file . '.php');
         }
 
         return $this->getFromCache($path);


### PR DESCRIPTION
Haven't tested it, but should work fairly well, and documented. If you add files like:

``` php
<?php

array(
    'foo' => 'something',
    'bar' => 'goes here',
)
```

In `master/config/example.php`, you should be able to get them with this class by calling `$config->get('example.foo')`. In this case, that will return "something".
