### PR TITLE
Fixed blank server list (issue #120)

### DIFF
--- a/app/languages/en.txt
+++ b/app/languages/en.txt
@@ -4,7 +4,7 @@ string.login, Login
 string.reset_password, Reset Password
 string.spam_protection, Spam Protection
 string.again, (Again)
-string.noservers, No servers have been assigned to your account yet
+string.noservers, No servers have been assigned to your account yet.
 string.node, Node
 string.name, Name
 string.connect, Connect

--- a/app/views/panel/servers.html
+++ b/app/views/panel/servers.html
@@ -48,7 +48,9 @@
             </tbody>
         </table>
     {% else %}
-        {{ lang.string_noservers }}
+        <div class="alert alert-info">
+            {{ lang.string_noservers }}
+        </div>
     {% endif %}
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
The blank server list that was shown when the user had no servers assigned to his account
has now been replaced with an error message.

You will have to add the other translations yourself (only added EN at the moment).
