### PR TITLE
Typo: severs -> servers in DROP TABLE statement

### DIFF
--- a/panel/admin/install/do/tables.php
+++ b/panel/admin/install/do/tables.php
@@ -160,7 +160,7 @@ if(file_exists('../install.lock'))
 	                        /*
 	                         * CREATE TABLE `servers`
 	                         */
-	                        $mysql->exec("DROP TABLE IF EXISTS `severs`");
+	                        $mysql->exec("DROP TABLE IF EXISTS `servers`");
 	                        $mysql->exec("CREATE TABLE `servers` (
 	                          `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
 	                          `gsd_id` int(11) DEFAULT NULL,


### PR DESCRIPTION
Prevents edge case where overwriting table `servers` in existing database will fail
