### PR TITLE
fixed username generation for useradd command by gsd

### DIFF
--- a/src/core/components/functions.php
+++ b/src/core/components/functions.php
@@ -36,7 +36,7 @@ trait Functions {
 	public static function generateFTPUsername($base) {
 
 		$username = (strlen($base) > 6) ? substr($base, 0, 6).'_'.self::keygen(5) : $base.'_'.self::keygen((11 - strlen($base)));
-	    return "mc-".$username;
+	    return "mc-".strtolower($username);
 
 	}
 


### PR DESCRIPTION
On some linux variants (like arch linux), usernames on the system are not allowed to have uppercase characters. You would get a error when creating a server on the panel because it would generate a username that has uppercase characters in it, therefor the useradd command would fail when gsd receives the call to create the server.

I hope you understand the request now
