### PR TITLE
The documentation for installing pufferpanel contains an error when issuing chmod command using parameter extension

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -58,7 +58,7 @@ After running composer we need to setup the other folders for the installer so t
 .. code-block:: sh
 
     [$]~ chmod -R 0777 panel/install/install
-    [$]~ chmod -R 0777 src/{core, logs, cache}
+    [$]~ chmod -R 0777 src/{core,logs,cache}
 
 Configuring MySQL
 -----------------


### PR DESCRIPTION
Parameter Extension will fail when using a comma seperated list followed by a whitespace.