### PR TITLE
Fixed subuser server list when they have access to multiple servers

### DIFF
--- a/src/core/permissions.php
+++ b/src/core/permissions.php
@@ -75,6 +75,13 @@ class Permissions extends User {
 			$servers = array_merge($servers, array($select['server']));
 		}
 
+		$select = ORM::forTable('servers')
+			->where(array('active' => 1, 'owner_id' => User::getData('id')))->findMany();
+
+		foreach($select as &$select) {
+			$servers = array_merge($servers, array($select['id']));
+		}
+
 		return $servers;
 
 	}

--- a/src/routes/panel/routes.php
+++ b/src/routes/panel/routes.php
@@ -160,10 +160,9 @@ $klein->respond('GET', '/[|index:index]', function($request, $response, $service
 			->select('servers.*')->select('nodes.name', 'node_name')->select('locations.long', 'location')
 			->join('nodes', array('servers.node', '=', 'nodes.id'))
 			->join('locations', array('nodes.location', '=', 'locations.id'))
-			->where(array('servers.owner_id' => $core->user->getData('id'), 'servers.active' => 1))
-			->where_raw('servers.owner_id = ? OR servers.id IN(?)', array($core->user->getData('id'), join(',', $core->permissions->listServers())))
-			->findArray();
-
+			->where(array('servers.active' => 1))
+			->where_in('servers.id', $core->permissions->listServers())
+			->findMany();
 	}
 
 	/*


### PR DESCRIPTION
Because of the way it was before, the `WHERE server.id IN (..)` statement got generated incorrectly by PDO (because of its inability to bind an array, and the method of joining a string didn't work quite right either).

I moved the logic of checking owner_id up to `Core\Permissions::listServers()` so we could just use where_in instead. 

It has been a while since I really dug down into PHP so please do tell me if you think I did something wrong. 