### PR TITLE
Add "/" to Command Box

### DIFF
--- a/app/views/node/index.html
+++ b/app/views/node/index.html
@@ -82,6 +82,7 @@
 						<form action="#" method="post" id="console_command">
 							<fieldset>
 								<div class="input-group">
+									<span class="input-group-addon">/</span>
 									<input type="text" class="form-control" name="command" id="ccmd" placeholder="{{ l.render('node.console.command_help') }}" />
 									<span class="input-group-btn">
 										<button id="sending_command" class="btn btn-primary btn-sm">&rarr;</button>


### PR DESCRIPTION
Some of my new clients were having trouble submitting commands, when all they were doing is putting a "/" in-front of the command, when it isn't needed. So I decided to add it!