### PR TITLE
$response->json sends the response immediately, fixes #633

### DIFF
--- a/src/routes/admin/server/routes.php
+++ b/src/routes/admin/server/routes.php
@@ -874,6 +874,6 @@ $klein->respond('POST', '/admin/server/new/plugin-variables', function($request,
 			)
 		),
 		'startup' => $orm->default_startup
-	))->send();
+	));
 
 });


### PR DESCRIPTION
This fixes #633.  `$response->json` sends the response, and doesn't need a `->send()`