### PR TITLE
Enable the usage of letsencrypt's webroot plugin

### DIFF
--- a/pufferpanel
+++ b/pufferpanel
@@ -209,6 +209,10 @@ function configureNginx() {
             fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
             include /etc/nginx/fastcgi_params;
         }
+        
+        location /.well-known/acme-challenge/ {
+            try_files $uri =404;
+        }
 
         location /assets {
             try_files /app/\$uri =404;
@@ -233,6 +237,9 @@ function configureNginx() {
     #        fastcgi_index router.php;
     #        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
     #        include /etc/nginx/fastcgi_params;
+    #    }
+    #    location /.well-known/acme-challenge/ {
+    #        try_files $uri =404;
     #    }
     #
     #    location /assets {


### PR DESCRIPTION
Makes the directory that letsencrypt tries to use to verify that you own your domain available.

Closes #683.