### PR TITLE
Fix URL Settings bug.

### DIFF
--- a/src/routes/admin/settings/routes.php
+++ b/src/routes/admin/settings/routes.php
@@ -159,8 +159,7 @@ $klein->respond('POST', '/admin/settings/[:page]/[:action]', function($request, 
 		$urls = array();
 		foreach(array(
 			'main_url' => $request->param('main_url'),
-			'master_url' => $request->param('master_url'),
-			'assets_url' => $request->param('assets_url')
+			'master_url' => $request->param('master_url')
 		) as $id => $val) {
 
 			$url = parse_url($val);


### PR DESCRIPTION
Apparently, the asset url setting was a feature that was removed for some reason, but one of the lines in the php still dealt with it, even though there was no longer any way to specify it.
Fixes #693.