### PR TITLE
Add scroll to bottom button of ScrollStop modal.

### DIFF
--- a/app/views/node/index.html
+++ b/app/views/node/index.html
@@ -236,6 +236,7 @@
 				</div>
 			</div>
 			<div class="modal-footer">
+				<button id="scrollbot" type="button" class="btn btn-primary">Scroll To Bottom</button>
 				<button type="button" class="btn btn-default" data-dismiss="modal">{{ l.render('string.close') }}</button>
 			</div>
 		</div>
@@ -287,6 +288,9 @@
 		$("#pause_console").click(function(){
 			$("#paused_console").val();
 			$("#paused_console").val($("#live_console").val());
+		});
+		$("#scrollbot").click(function(){
+			$('#paused_console').scrollTop($('#paused_console')[0].scrollHeight);
 		});
 		var ctx = $("#memoryChart").get(0).getContext("2d");
 		var cty = $("#cpuChart").get(0).getContext("2d");


### PR DESCRIPTION
Since the purpose of ScrollStop is to quickly grab what just flashed past you, it makes sense to have a single button you can click to jump to the most recent data rather than having to scroll to the bottom every time.

I'm about to roll this out for my entire network, and I would consider this a significant usability issue with a very simple fix.