### PR TITLE
Increased size of ScrollStop to fill page.

### DIFF
--- a/app/assets/css/pufferpanel.css
+++ b/app/assets/css/pufferpanel.css
@@ -71,3 +71,6 @@ pre{display:block;padding:12px 12px;margin:0;font-size:12px;color:#c7254e;backgr
 .badge.label-danger {background: #d9534f !important;}
 .close {color:#000;opacity:0.2;font-size:1.6em;}
 .close:hover {color:#000;opacity:0.5;}
+#pauseConsole .modal-dialog {width: 100%;height: 100%;padding: 0; margin: 0;}
+#pauseConsole .modal-content {height: 100%;min-height: 100%;height: auto;border-radius: 0;}
+#pauseConsole.modal .console {height: 75vh !important;}


### PR DESCRIPTION
Since the purpose of ScrollStop is to quickly grab what just flashed past you, it makes sense to have a larger window to view the latest console data.

I'm about to roll this out for my entire network, and I would consider this a significant usability issue with a very simple fix.