### PR TITLE
Remove exit from index.php for Apache Support

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,5 @@
 <?php
 
 header('Location: /index');
-exit();
 
 ?>


### PR DESCRIPTION
Removed exit from index.php due to the fact it was not making apache work.