### PR TITLE
INSTALLER-CONFIRM-PW: Add confirm password dialog to pufferpanel inst…

### DIFF
--- a/pufferpanel
+++ b/pufferpanel
@@ -150,10 +150,31 @@ function configureUser() {
         echo -n "Email: "
         read email
     done
-    while [ "${password}" == "" ]; do
-        echo -n "Password: "
-        read -s password
+    
+    password=""
+    password2=""
+    while true; do
+        while [ "${password}" == "" ]; do
+            echo "Password: "
+            read -s password
+            echo ""
+        done
+        
+        while [ "${password2}" == "" ]; do
+            echo "Confirm Password: "
+            read -s password2
+            echo ""
+        done
+        
+        if [ "${password}" != "${password2}" ]; then
+            echo "Password does not match the confirm password! Please try again."
+            password=""
+            password2=""
+        else
+            break
+        fi
     done
+    
     password=$(php -r "echo password_hash('"${password}"', PASSWORD_BCRYPT);");
     time=$(php -r 'echo time();');
 


### PR DESCRIPTION
[FEAUTER-REQUEST]

When executing pufferpanel install script a password for the first User is asked but without confirmation. 

Sometimes you may mistype a password even if you think you typed it in correctly. This makes sure that the password does match the confirm password so you wont be standing in front of the admin panel and have to modify the database or re-run installer.

Best wishes,
lycano