### PR TITLE
Fixed URL encoding issue for file upload

### DIFF
--- a/src/routes/daemon/routes.php
+++ b/src/routes/daemon/routes.php
@@ -126,7 +126,7 @@ $klein->respond('/daemon/server/[:serverid]/[**:path]', function($request, $resp
         );
     }
 
-    $updatedUrl = sprintf('%s/server/%s/%s', Daemon::buildBaseUrlForNode($nodeObj->ip, $nodeObj->daemon_listen), $server, $request->param('path'));
+    $updatedUrl = sprintf('%s/server/%s/%s', Daemon::buildBaseUrlForNode($nodeObj->ip, $nodeObj->daemon_listen), $server, urlencode($request->param('path')));
 
     foreach($oldHeaders as $k => $v) {
         if ($v !== '') {


### PR DESCRIPTION
This commit fixes an issue where uploaded filenames have characters
requiring URL encoding.

The proxy failed when the filename had characters (such as a space) that
need to be escaped.  The filename portion of the request was not
properly encoded and that caused a server error in pufferd (as it ended
up being an invalid request that could not be parsed).
