### PR TITLE
reduce length of email field

### DIFF
--- a/install/install.sql
+++ b/install/install.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `uuid` char(36) NOT NULL,
   `username` varchar(50) NOT NULL,
-  `email` varchar(255) NOT NULL,
+  `email` varchar(128) NOT NULL,
   `password` text,
   `language` varchar(10) NOT NULL DEFAULT 'en_US',
   `register_time` int(15) unsigned NOT NULL,


### PR DESCRIPTION
reduce length of email field to fix installation error "Index column size too large. The maximum column size is 767 bytes."
Refer to https://community.pufferpanel.com/post/2998

Please make sure to read the CONTRIBUTING.md file before submitting your pull request.
Please remove these two lines before submitting your Pull Request.
