### PR TITLE
Fix getPhpConfLocation wildcard expansion

### DIFF
--- a/pufferpanel
+++ b/pufferpanel
@@ -405,7 +405,7 @@ function getPhpConfLocation(){
 
     for loc in "${wwwConfLocations[@]}"; do
         echo "$loc"
-        if [ -e "${loc}" ]; then
+        if compgen -G "$loc"; then
             phpWWWConfLocation="$loc"
             break
         fi


### PR DESCRIPTION
Fixes #820 
Testing a quoted glob will not expand the glob, so `"/etc/php/*/fpm/pool.d/www.conf"` doesn't match anything.
Changed to use bash builtin `compgen` instead, which will expand the glob and succeed if there were any matches found.