### PR TITLE
fix some versions of maria db throwing errors about key sizes

### DIFF
--- a/install/install.sql
+++ b/install/install.sql
@@ -1,5 +1,5 @@
 -- Remove existing database and create new
-CREATE DATABASE IF NOT EXISTS `pufferpanel`;
+CREATE DATABASE IF NOT EXISTS `pufferpanel` CHARACTER SET `utf8`;
 USE `pufferpanel`;
 
 -- Disable Foreign keys to avoid errors in dropping


### PR DESCRIPTION
Some versions of MariaDB use utf8mb4 as default charset which causes varchar(255) to be too long, explicitly using utf8 instead fixes this