### PR TITLE
properly escape generated passwords

### DIFF
--- a/pufferpanel
+++ b/pufferpanel
@@ -95,7 +95,7 @@ function configureMysql() {
         \"host\": \"${mysqlHost}\",
         \"database\": \"${mysqlDb}\",
         \"username\": \"${newUser}\",
-        \"password\": \"${newPw}\",
+        \"password\": \"$(echo $newPw | awk '{gsub(/\\/, "\\\\"); print}')\",
         \"port\": \"${mysqlPort}\"
     }
 }" > config.json


### PR DESCRIPTION
escape backslashes in generated passwords to make them json safe
