### PR TITLE
pufferpanel user add now follows same validations as the user api

### DIFF
--- a/cmd/user.go
+++ b/cmd/user.go
@@ -80,7 +80,7 @@ func addUser(cmd *cobra.Command, args []string) {
 			Prompt: &survey.Input{
 				Message: "Username:",
 			},
-			Validate: survey.Required,
+			Validate: validateUsername,
 		})
 	}
 
@@ -90,7 +90,7 @@ func addUser(cmd *cobra.Command, args []string) {
 			Prompt: &survey.Input{
 				Message: "Email:",
 			},
-			Validate: survey.Required,
+			Validate: validateEmail,
 		})
 	}
 
@@ -173,6 +173,32 @@ func addUser(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Printf("User added\n")
+}
+
+func validateEmail(val interface{}) error {
+	email := val.(string)
+
+	var viewModel models.UserView
+	viewModel.Email = email
+	err := viewModel.EmailValid(false)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateUsername(val interface{}) error {
+	usr := val.(string)
+
+	var viewModel models.UserView
+	viewModel.Username = usr
+	err := viewModel.UserNameValid(false)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func validatePassword(val interface{}) error {

--- a/models/userview.go
+++ b/models/userview.go
@@ -61,6 +61,21 @@ func (model *UserView) CopyToModel(newModel *User) {
 }
 
 func (model *UserView) Valid(allowEmpty bool) error {
+
+	userNameErr := model.UserNameValid(allowEmpty)
+	if(userNameErr != nil){
+		return userNameErr
+	}
+
+	mailErr := model.EmailValid(allowEmpty)
+	if(mailErr != nil){
+		return mailErr
+	}
+
+	return nil
+}
+
+func (model *UserView) UserNameValid(allowEmpty bool) error {
 	validate := validator.New()
 
 	if !allowEmpty && validate.Var(model.Username, "required") != nil {
@@ -79,6 +94,13 @@ func (model *UserView) Valid(allowEmpty bool) error {
 	if testName != model.Username {
 		return pufferpanel.ErrFieldHasURICharacters("username")
 	}
+
+	return nil
+}
+
+
+func (model *UserView) EmailValid(allowEmpty bool) error {
+	validate := validator.New()
 
 	if !allowEmpty && validate.Var(model.Email, "required") != nil {
 		return pufferpanel.ErrFieldRequired("email")


### PR DESCRIPTION
Kind of fixed bug~s #941 and~ #946, user added an ilegal username deemed so by the username validations of the user api, which aren't followed by the `$ pufferpanel user add` command. The PR slightly modifies the validation splitting it into user and email so it can be independently checked from the user add cmd.