### PR TITLE
ScopeServersConsoleSend was not used in front and backend

### DIFF
--- a/client/src/components/server/console.vue
+++ b/client/src/components/server/console.vue
@@ -1,6 +1,20 @@
 <template>
   <v-card>
-    <v-card-title v-text="$t('servers.Console')" />
+    <v-card-title>
+      <span v-text="$t('servers.Console')" />
+      <div class="flex-grow-1" />
+      <v-btn
+        icon
+        @click="popoutConsole"
+      >
+        <v-icon
+          :dark="isDark()"
+          :light="!isDark()"
+        >
+          mdi-pause
+        </v-icon>
+      </v-btn>
+    </v-card-title>
     <v-card-text>
       <v-textarea
         id="console"
@@ -14,15 +28,14 @@
         class="console"
       />
       <v-text-field
+        v-if="server.permissions.sendServerConsole"
         v-model="consoleCommand"
         outlined
         hide-details
         placeholder="Command..."
         append-icon="mdi-send"
-        append-outer-icon="mdi-pause"
         class="pt-2"
         @click:append="sendCommand"
-        @click:append-outer="popoutConsole"
         @keyup.enter="sendCommand"
       />
       <v-overlay :value="consolePopup">
@@ -70,6 +83,9 @@
 import { isDark } from '@/utils/dark'
 
 export default {
+  props: {
+    server: { type: Object, default: () => {} }
+  },
   data () {
     return {
       console: '',

--- a/web/daemon/websocket.go
+++ b/web/daemon/websocket.go
@@ -120,10 +120,12 @@ func listenOnSocket(conn *pufferpanel.Socket, server *programs.Program, scopes [
 				}
 			case "console":
 				{
-					cmd, ok := mapping["command"].(string)
-					if ok {
-						if run, _ := server.IsRunning(); run {
-							_ = server.GetEnvironment().ExecuteInMainProcess(cmd)
+					if pufferpanel.ContainsScope(scopes, pufferpanel.ScopeServersConsoleSend) {
+						cmd, ok := mapping["command"].(string)
+						if ok {
+							if run, _ := server.IsRunning(); run {
+								_ = server.GetEnvironment().ExecuteInMainProcess(cmd)
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Proposed fix for issue #941. Though the backend fix seems to work fine, in the frontend fix I gave an id to the input so on the server permissions request I can disable the input and fill the placeholderhas but it has a couple of cons:
 - If you change the language the placeholder text doesn't update unless reloading the page
 - The send button remains enabled

The second solution fixes it "inline", and the placeholder does change when switching language.
 - It has to make an extra request so it delays the load of the console block
 - When disabling the input with `:disabled`, the pause icon at the right which opens the console also gets disabled.
 
diff of the second frontend proposed solution:
```diff
diff --git a/client/src/components/server/console.vue b/client/src/components/server/console.vue
index 09ddcc78..a8f77991 100644
--- a/client/src/components/server/console.vue
+++ b/client/src/components/server/console.vue
@@ -17,7 +17,8 @@
         v-model="consoleCommand"
         outlined
         hide-details
-        placeholder="Command..."
+        :placeholder="server.permissions.sendServerConsole ? 'Command...' : $t('errors.ErrNoPermission') + ': ' + $t('scopes.ServersConsoleSend')"
+        :disabled="!server.permissions.sendServerConsole"
         append-icon="mdi-send"
         append-outer-icon="mdi-pause"
         class="pt-2"
@@ -68,6 +69,7 @@
 
 <script>
 import { isDark } from '@/utils/dark'
+import { handleError } from '@/utils/api'
 
 export default {
   data () {
@@ -96,6 +98,7 @@ export default {
       this.$socket.sendObj({ type: 'replay' })
     })
     this.refreshInterval = setInterval(this.updateConsole, 1000)
+    this.server = this.loadServer()
   },
   beforeDestroy () {
     if (this.refreshInterval !== null) {
@@ -156,7 +159,14 @@ export default {
 
       this.consoleCommand = ''
     },
-    isDark
+    isDark,
+    loadServer () {
+      const ctx = this
+      this.$http.get(`/api/servers/${this.$route.params.id}?perms`).then(response => {
+        ctx.server = response.data.server
+        ctx.server.permissions = response.data.permissions
+      }).catch(handleError(ctx))
+    }
   }
 }
 </script>
```

None of the fixes are ideal, but I'm open to suggestions on how to improve them