### PR TITLE
Fix for users unable to view servers when using PostgreSQL.

### DIFF
--- a/services/server.go
+++ b/services/server.go
@@ -46,7 +46,7 @@ func (ss *Server) Search(searchCriteria ServerSearch) (records *models.Servers, 
 	}
 
 	if searchCriteria.Username != "" {
-		query = query.Joins("JOIN permissions p ON servers.identifier = p.server_identifier AND p.view_server = 1")
+		query = query.Joins("JOIN permissions p ON servers.identifier = p.server_identifier AND p.view_server = '1'")
 		query = query.Joins("JOIN users ON p.user_id = users.id")
 		query = query.Where("users.username = ?", searchCriteria.Username)
 	}


### PR DESCRIPTION
Hey guys, I've discovered a bug when creating a new user with only See all Servers, See Nodes, See Templates permissions added. 
Issue is not present with a user with full admin permissions.

PostgreSQL Error log:
```
2021-01-09 09:57:07.610 UTC [1230114] pufferpanel@pufferpanel ERROR:  operator does not exist: boolean = integer at character 113
2021-01-09 09:57:07.610 UTC [1230114] pufferpanel@pufferpanel HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
2021-01-09 09:57:07.610 UTC [1230114] pufferpanel@pufferpanel STATEMENT:  SELECT count(*) FROM "servers" JOIN permissions p ON servers.identifier = p.server_identifier AND p.view_server = 1 JOIN users ON p.user_id = users.id WHERE (users.username = $1)
```
