### PR TITLE
Fix error on swagger (#1048)

### DIFF
--- a/web/api/nodes.go
+++ b/web/api/nodes.go
@@ -232,7 +232,7 @@ func deleteNode(c *gin.Context) {
 // @Failure 404 {object} response.Error
 // @Failure 500 {object} response.Error
 // @Param id path string true "Node Id"
-// @Router /api/nodes/{id}/deploy [get]
+// @Router /api/nodes/{id}/deployment [get]
 func deployNode(c *gin.Context) {
 	var err error
 	db := middleware.GetDatabase(c)


### PR DESCRIPTION
Swagger say that the link for the api to get deployment is ​/api​/nodes​/{id}​/deploy but good link is ​/api​/nodes​/{id}​/deployment
![image](https://user-images.githubusercontent.com/67557705/129898066-c2d192d2-fa69-4cc9-a24e-c3b4173d441e.png)
![image](https://user-images.githubusercontent.com/67557705/129898132-d1c01f4d-e35b-44e5-95c6-c3a26a6b4803.png)
