### PR TITLE
Add Ubuntu/Jammy AMD64 and ARM64 to the releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,16 +219,19 @@ jobs:
         
         package_cloud push ${{ github.event.inputs.repo }}/fedora/33 ${{ steps.amd64rpmdownload.outputs.file }}
         
-        #ubuntu
+        #ubuntu AMD64
         package_cloud push ${{ github.event.inputs.repo }}/ubuntu/bionic ${{ steps.amd64debdownload.outputs.file }}
         package_cloud push ${{ github.event.inputs.repo }}/ubuntu/cosmic ${{ steps.amd64debdownload.outputs.file }}
         package_cloud push ${{ github.event.inputs.repo }}/ubuntu/disco ${{ steps.amd64debdownload.outputs.file }}
         package_cloud push ${{ github.event.inputs.repo }}/ubuntu/eoan ${{ steps.amd64debdownload.outputs.file }}
         package_cloud push ${{ github.event.inputs.repo }}/ubuntu/focal ${{ steps.amd64debdownload.outputs.file }}
         package_cloud push ${{ github.event.inputs.repo }}/ubuntu/groovy ${{ steps.amd64debdownload.outputs.file }}
+        package_cloud push ${{ github.event.inputs.repo }}/ubuntu/jammy ${{ steps.amd64debdownload.outputs.file }}
         
+        #ubuntu ARM64
         package_cloud push ${{ github.event.inputs.repo }}/ubuntu/focal ${{ steps.arm64debdownload.outputs.file }}
         package_cloud push ${{ github.event.inputs.repo }}/ubuntu/groovy ${{ steps.arm64debdownload.outputs.file }}
+        package_cloud push ${{ github.event.inputs.repo }}/ubuntu/jammy ${{ steps.arm64debdownload.outputs.file }}
         
         #debian
         package_cloud push ${{ github.event.inputs.repo }}/debian/jessie ${{ steps.amd64debdownload.outputs.file }}


### PR DESCRIPTION
As mentioned in the title, 

I have added Ubuntu/Jammy AMD64 and ARM64 to the releases.

I have also added a heading to clearly outline the Ubuntu AMD64 builds and ARM Builds

