### PR TITLE
Fix errors in tests

### DIFF
--- a/mappings_test.go
+++ b/mappings_test.go
@@ -255,7 +255,7 @@ func TestGetStringArrayOrNull(t *testing.T) {
 			name: "Test for invalid type",
 			args: args{
 				data: mappingTest,
-				key:  mappingIntArrayKey,
+				key:  mappingMapKey,
 			},
 			want: nil,
 		},

--- a/models/nodeview_test.go
+++ b/models/nodeview_test.go
@@ -20,10 +20,10 @@ import (
 
 func TestFromNodes(t *testing.T) {
 	type args struct {
-		n *Nodes
+		n []*Node
 	}
 
-	sourceNode := make(Nodes, 1)
+	sourceNode := make([]*Node, 1)
 	sourceNode[0] = &Node{
 		ID:          5,
 		Name:        "node",
@@ -54,7 +54,7 @@ func TestFromNodes(t *testing.T) {
 		{
 			name: "conversion",
 			args: args{
-				n: &sourceNode,
+				n: sourceNode,
 			},
 			want: &desired,
 		},


### PR DESCRIPTION
This change fixes compilation error in `models/nodeview_test.go` and a test case input in `mappings_test.go`.
