### PR TITLE
Enable AutoFill for OTP code in Safari

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -235,6 +235,7 @@
             <ui-input
               v-model="otpToken"
               autofocus
+              autocomplete="one-time-code"
               @keyup.enter="confirmOtp"
             />
           </v-col>

--- a/client/src/components/ui/input.vue
+++ b/client/src/components/ui/input.vue
@@ -8,6 +8,7 @@
     :filled="lookValue === 'filled'"
     :flat="flat"
     :autofocus="autofocus"
+    :autocomplete="autocomplete"
     :dense="dense"
     :disabled="disabled"
     :label="label"
@@ -39,6 +40,7 @@ const allowedLooks = ['outlined', 'solo', 'solo-flat', 'filled', 'material']
 export default {
   props: {
     autofocus: { type: Boolean, default: () => false },
+    autocomplete: { type: String, default: () => undefined },
     dense: { type: Boolean, default: () => false },
     disabled: { type: Boolean, default: () => false },
     endIcon: { type: String, default: () => undefined },


### PR DESCRIPTION
This change enables AutoFill for OTP in Safari (and likely in some other browsers) by setting the autocomplete HTML attribute on input element.

https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_an_html_input_element
