### PR TITLE
Add IDs for username and password to Login.vue

### DIFF
--- a/client/frontend/src/views/Login.vue
+++ b/client/frontend/src/views/Login.vue
@@ -97,8 +97,8 @@ function passwordErrorMsg() {
   <div class="login">
     <h1 v-text="t('users.Login')" />
     <form @keydown.enter="login()">
-      <text-field v-model="email" type="email" name="email" :label="t('users.Email')" :error="emailErrorMsg()" icon="email" autofocus @blur="now(validateEmail)" @change="wait(validateEmail)" />
-      <text-field v-model="password" type="password" name="password" :label="t('users.Password')" :error="passwordErrorMsg()" icon="lock" @blur="now(validatePassword)" @change="wait(validatePassword)" />
+      <text-field v-model="email" type="email" name="email" id="email" :label="t('users.Email')" :error="emailErrorMsg()" icon="email" autofocus @blur="now(validateEmail)" @change="wait(validateEmail)" />
+      <text-field v-model="password" type="password" name="password" id="password" :label="t('users.Password')" :error="passwordErrorMsg()" icon="lock" @blur="now(validatePassword)" @change="wait(validatePassword)" />
       <btn color="primary" :disabled="emailError || passwordError" @click="login()" v-text="t('users.Login')" />
       <btn v-if="$config.registrationEnabled" variant="text" @click="$router.push({ name: 'Register' })" v-text="t('users.RegisterLink')" />
     </form>


### PR DESCRIPTION
Some password safes don't recognize the username and password for autofill

Bitwarden:
![image](https://github.com/pufferpanel/pufferpanel/assets/69628182/a4c3b6ae-84d2-48c5-a9b4-1c9d7ff5d6c9)
Text in English: "The fields on this page could not be filled automatically. Please manually copy the username and/or password."
