### PR TITLE
Docker Labels

### DIFF
--- a/servers/docker/docker.go
+++ b/servers/docker/docker.go
@@ -331,11 +331,7 @@ func (d *Docker) createContainer(ctx context.Context, data pufferpanel.Execution
 	}
 
 	for k, v := range d.Labels {
-		labels[k] = v
-	}
-
-	for k, v := range labels {
-		labels[k] = pufferpanel.ReplaceTokens(v, data.Variables)
+		labels[pufferpanel.ReplaceTokens(k, data.Variables)] = pufferpanel.ReplaceTokens(v, data.Variables)
 	}
 
 	c := d.Config


### PR DESCRIPTION
Hello,
This change permit to use environment vars in labels keys as well as in the value : 

```
"supportedEnvironments": [
        {
            "type": "host"
        },
        {
            "type": "docker",
            "image": "eclipse-temurin:${javaversion}",
            "labels": {
                "javaversion": "${javaversion}",
                "mcversion": "${version}",
                "traefik.enable": "true",
                .....
                "traefik.http.routers.${username}_mc.service": "mc",
                "username": "${username}"
            }
        }
    ],
```
