### PR TITLE
Bug fix for #1417

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -144,6 +144,10 @@ var ErrPathNotAbs = func(path string) *Error {
 	return CreateError("path not abs: ${path}", "ErrPathNotAbs").Metadata(map[string]interface{}{"path": path})
 }
 
+var ErrCurseForgeDistribution = func(projectId uint) *Error {
+	return CreateError("CurseForge modpack with project ID ${projectId} does not allow third-party distribution", "ErrCurseForgeDistribution").Metadata(map[string]interface{}("projectId": projectId))
+}
+
 func GenerateValidationMessage(err error) error {
 	var errs validator.ValidationErrors
 	if errors.As(err, &errs) {

--- a/errors.go
+++ b/errors.go
@@ -145,7 +145,15 @@ var ErrPathNotAbs = func(path string) *Error {
 }
 
 var ErrCurseForgeDistribution = func(projectId uint) *Error {
-	return CreateError("CurseForge modpack with project ID ${projectId} does not allow third-party distribution", "ErrCurseForgeDistribution").Metadata(map[string]interface{}("projectId": projectId))
+	return CreateError("CurseForge modpack with project ID ${projectId} does not allow third-party distribution", "ErrCurseForgeDistribution").Metadata(map[string]interface{}{"projectId": projectId})
+}
+
+var ErrCurseForgeFile = func(projectId uint, fileId uint) *Error {
+	return CreateError("File ID ${fileId} under project ID ${projectId} not found", "ErrCurseForgeFile").Metadata(map[string]interface{}{"fileId": fileId, "projectId": projectId})
+}
+
+var ErrCurseForgeStatus = func(status string) *Error {
+	return CreateError("Invalid status code from CurseForge: ${status}", "ErrCurseForgeStatus").Metadata(map[string]interface{}{"status": status})
 }
 
 func GenerateValidationMessage(err error) error {

--- a/operations/curseforge/client.go
+++ b/operations/curseforge/client.go
@@ -12,8 +12,7 @@ import (
 	"net/url"
 )
 
-func getAddonData(projectId uint) (AddonResponse, error)
-{
+func getAddonData(projectId uint) (AddonResponse, error) {
 	u := fmt.Sprintf("https://api.curseforge.com/v1/mods/%d", projectId)
 
 	response, err := callCurseForge(u)
@@ -43,8 +42,7 @@ func getAddonData(projectId uint) (AddonResponse, error)
 	return addon, nil
 }
 
-func getAddonFileData(projectId uint, fileId uint) (FileResponse, error)
-{
+func getAddonFileData(projectId uint, fileId uint) (FileResponse, error) {
 	u := fmt.Sprintf("https://api.curseforge.com/v1/mods/%d/files/%d", projectId, fileId)
 
 	response, err := callCurseForge(u)

--- a/operations/curseforge/client.go
+++ b/operations/curseforge/client.go
@@ -3,13 +3,14 @@ package curseforge
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
 	"github.com/pufferpanel/pufferpanel/v3"
 	"github.com/pufferpanel/pufferpanel/v3/config"
 	"github.com/pufferpanel/pufferpanel/v3/logging"
 	"github.com/pufferpanel/pufferpanel/v3/utils"
-	"io"
-	"net/http"
-	"net/url"
 )
 
 func getAddonData(projectId uint) (AddonResponse, error) {
@@ -76,12 +77,12 @@ func getLatestFiles(projectId uint) ([]File, error) {
 	if !addon.Data.AllowModDistribution {
 		return nil, pufferpanel.ErrCurseForgeDistribution(projectId)
 	}
-				       
+
 	return addon.Data.LatestFiles, err
 }
 
 func getFileById(projectId uint, fileId uint) (File, error) {
-	addon, addonErr := getAddonData(projectId, fileId)
+	addon, addonErr := getAddonData(projectId)
 
 	if addonErr != nil {
 		return File{}, addonErr
@@ -90,13 +91,13 @@ func getFileById(projectId uint, fileId uint) (File, error) {
 	if !addon.Data.AllowModDistribution {
 		return File{}, pufferpanel.ErrCurseForgeDistribution(projectId)
 	}
-	
+
 	file, fileErr := getAddonFileData(projectId, fileId)
 
 	if fileErr != nil {
 		return File{}, fileErr
 	}
-				       
+
 	return file.Data, nil
 }
 

--- a/operations/curseforge/client.go
+++ b/operations/curseforge/client.go
@@ -83,7 +83,7 @@ func getLatestFiles(projectId uint) ([]File, error) {
 }
 
 func getFileById(projectId uint, fileId uint) (File, error) {
-	addon, addonErr := getaddonData(projectId, fileId)
+	addon, addonErr := getAddonData(projectId, fileId)
 
 	if addonErr != nil {
 		return File{}, addonErr

--- a/operations/curseforge/client.go
+++ b/operations/curseforge/client.go
@@ -12,7 +12,8 @@ import (
 	"net/url"
 )
 
-func getLatestFiles(projectId uint) ([]File, error) {
+func getAddonData(projectId uint) (AddonResponse, error)
+{
 	u := fmt.Sprintf("https://api.curseforge.com/v1/mods/%d", projectId)
 
 	response, err := callCurseForge(u)
@@ -39,29 +40,66 @@ func getLatestFiles(projectId uint) ([]File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return addon.Data.LatestFiles, err
+	return addon, nil
 }
 
-func getFileById(projectId, fileId uint) (File, error) {
+func getAddonFileData(projectId uint, fileId uint) (FileRespnse, error)
+{
 	u := fmt.Sprintf("https://api.curseforge.com/v1/mods/%d/files/%d", projectId, fileId)
 
 	response, err := callCurseForge(u)
 	if err != nil {
-		return File{}, err
+		return nil, err
 	}
 	defer utils.CloseResponse(response)
 
 	if response.StatusCode == http.StatusNotFound {
-		return File{}, fmt.Errorf("file id %d not found", fileId)
+		return nil, fmt.Errorf("file id %d not found", fileId)
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return File{}, fmt.Errorf("invalid status code from CurseForge: %s", response.Status)
+		return nil, fmt.Errorf("invalid status code from CurseForge: %s", response.Status)
 	}
 
 	var res FileResponse
 	err = json.NewDecoder(response.Body).Decode(&res)
-	return res.Data, err
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func getLatestFiles(projectId uint) ([]File, error) {
+	addon, err := getAddonData(projectId)
+	if err != nil {
+		return nil, err
+	}
+
+	if addon.Data.AllowModDistribution != nil && !addon.Data.AllowModDistribution {
+		return nil, fmt.ErrorF("modpack with project ID %d is not marked for third-party distribution", projectId)
+	}
+				       
+	return addon.Data.LatestFiles, err
+}
+
+func getFileById(projectId uint, fileId uint) (File, error) {
+	addon, addonErr := getaddonData(projectId, fileId)
+
+	if addonErr != nil {
+		return nil, addonErr
+	}
+
+	if addon.Data.AllowModDistribution != nil && !addon.Data.AllowModDistribution {
+		return nil, fmt.ErrorF("modpack with project ID %d is not marked for third-party distribution", projectId)
+	}
+	
+	file, fileErr := getAddonFileData(projectId, fileId)
+
+	if fileErr != nil {
+		return nil, fileErr
+	}
+				       
+	return file.Data, nil
 }
 
 func callCurseForge(u string) (*http.Response, error) {

--- a/operations/curseforge/client.go
+++ b/operations/curseforge/client.go
@@ -75,8 +75,8 @@ func getLatestFiles(projectId uint) ([]File, error) {
 		return nil, err
 	}
 
-	if addon.Data.AllowModDistribution != nil && !addon.Data.AllowModDistribution {
-		return nil, fmt.ErrorF("modpack with project ID %d is not marked for third-party distribution", projectId)
+	if !addon.Data.AllowModDistribution {
+		return nil, pufferpanel.ErrCurseForgeDistribution(projectId)
 	}
 				       
 	return addon.Data.LatestFiles, err
@@ -86,17 +86,17 @@ func getFileById(projectId uint, fileId uint) (File, error) {
 	addon, addonErr := getaddonData(projectId, fileId)
 
 	if addonErr != nil {
-		return nil, addonErr
+		return File{}, addonErr
 	}
 
-	if addon.Data.AllowModDistribution != nil && !addon.Data.AllowModDistribution {
-		return nil, fmt.ErrorF("modpack with project ID %d is not marked for third-party distribution", projectId)
+	if !addon.Data.AllowModDistribution {
+		return File{}, pufferpanel.ErrCurseForgeDistribution(projectId)
 	}
 	
 	file, fileErr := getAddonFileData(projectId, fileId)
 
 	if fileErr != nil {
-		return nil, fileErr
+		return File{}, fileErr
 	}
 				       
 	return file.Data, nil

--- a/operations/curseforge/client.go
+++ b/operations/curseforge/client.go
@@ -18,53 +18,53 @@ func getAddonData(projectId uint) (AddonResponse, error)
 
 	response, err := callCurseForge(u)
 	if err != nil {
-		return nil, err
+		return AddonResponse{}, err
 	}
 	defer utils.CloseResponse(response)
 
 	if response.StatusCode == http.StatusNotFound {
-		return nil, nil
+		return AddonResponse{}, nil
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("invalid status code from CurseForge: %s", response.Status)
+		return AddonResponse{}, pufferpanel.ErrCurseForgeStatus(response.Status)
 	}
 
 	d, err := io.ReadAll(response.Body)
 	if err != nil {
-		return nil, err
+		return AddonResponse{}, err
 	}
 
 	var addon AddonResponse
 	err = json.Unmarshal(d, &addon)
 	if err != nil {
-		return nil, err
+		return AddonResponse{}, err
 	}
 	return addon, nil
 }
 
-func getAddonFileData(projectId uint, fileId uint) (FileRespnse, error)
+func getAddonFileData(projectId uint, fileId uint) (FileResponse, error)
 {
 	u := fmt.Sprintf("https://api.curseforge.com/v1/mods/%d/files/%d", projectId, fileId)
 
 	response, err := callCurseForge(u)
 	if err != nil {
-		return nil, err
+		return FileResponse{}, err
 	}
 	defer utils.CloseResponse(response)
 
 	if response.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("file id %d not found", fileId)
+		return FileResponse{}, pufferpanel.ErrCurseForgeFile(projectId, fileId)
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("invalid status code from CurseForge: %s", response.Status)
+		return FileResponse{}, pufferpanel.ErrCurseForgeStatus(response.Status)
 	}
 
 	var res FileResponse
 	err = json.NewDecoder(response.Body).Decode(&res)
 	if err != nil {
-		return nil, err
+		return FileResponse{}, err
 	}
 	return res, nil
 }

--- a/operations/curseforge/models.go
+++ b/operations/curseforge/models.go
@@ -3,12 +3,13 @@ package curseforge
 import "time"
 
 type Addon struct {
-	Id           uint
-	Name         string
-	DateCreated  time.Time
-	DateModified time.Time
-	DateReleased time.Time
-	LatestFiles  []File `json:"latestFiles"`
+	Id                   uint
+	Name                 string
+	DateCreated          time.Time
+	DateModified         time.Time
+	DateReleased         time.Time
+	AllowModDistribution bool
+	LatestFiles          []File `json:"latestFiles"`
 }
 
 type File struct {


### PR DESCRIPTION
Add the `AllowModDistribution` boolean from the [CurseForge Mod API response](https://docs.curseforge.com/rest-api/#tocS_Mod) to the `Addon` model and add a check in the client to return an error if this is set to false. This is to fix issue #1417 where the client does not handle the `AllowModDistribution` flag and returns an improper error message.