### PR TITLE
Save file using Ctrl+S

### DIFF
--- a/client/frontend/src/components/server/files/Editor.vue
+++ b/client/frontend/src/components/server/files/Editor.vue
@@ -71,6 +71,6 @@ export default {
       <source :src="modelValue.url" />
       <div class="warning unsupported" v-text="t('errors.AudioUnsupported')" />
     </audio>
-    <ace v-else id="file-editor" :read-only="readOnly" :model-value="modelValue.content" class="file-editor" :file="modelValue.name" theme="monokai" @update:modelValue="emitUpdate" />
+    <ace v-else id="file-editor" :read-only="readOnly" :model-value="modelValue.content" class="file-editor" :file="modelValue.name" theme="monokai" @update:modelValue="emitUpdate" @save="emit('save')" />
   </div>
 </template>

--- a/client/frontend/src/components/ui/Ace.vue
+++ b/client/frontend/src/components/ui/Ace.vue
@@ -9,7 +9,7 @@ const props = defineProps({
   modelValue: { type: String, required: true }
 })
 
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue', 'save'])
 
 const el = ref(null)
 
@@ -74,6 +74,13 @@ function init() {
       bindKey: { win: 'Escape', mac: 'Escape' },
       exec: (editor) => {
         editor.blur()
+      }
+    })
+    editor.commands.addCommand({
+      name: 'save',
+      bindKey: { win: 'Ctrl-S', mac: 'Cmd-S' },
+      exec: () => {
+        emit('save')
       }
     })
   })


### PR DESCRIPTION
Adds Ctrl+S as a shortcut to save the current file. Might be a good idea to add an indication that the file was saved instead of closing it.