### PR TITLE
Add PaperMC download operation

### DIFF
--- a/download.go
+++ b/download.go
@@ -2,10 +2,12 @@ package pufferpanel
 
 import (
 	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"github.com/pufferpanel/pufferpanel/v3/config"
 	"github.com/pufferpanel/pufferpanel/v3/logging"
 	"github.com/pufferpanel/pufferpanel/v3/utils"
+	"hash"
 	"io"
 	"log"
 	"os"
@@ -57,14 +59,19 @@ func DownloadFileToCache(url, fileName string) error {
 	return err
 }
 
-func DownloadViaMaven(downloadUrl string, env *Environment) (string, error) {
+type FileHash int
+
+const (
+	FileHashSHA1 = iota
+	FileHashSHA256
+)
+
+func FileFromCacheOrDownload(downloadUrl, expectedHash string, algorithm FileHash, env *Environment) (string, error) {
 	localPath := filepath.Join(config.CacheFolder.Value(), strings.TrimPrefix(strings.TrimPrefix(downloadUrl, "http://"), "https://"))
 
 	if os.PathSeparator != '/' {
 		localPath = strings.Replace(localPath, "/", string(os.PathSeparator), -1)
 	}
-
-	sha1Url := downloadUrl + ".sha1"
 
 	if env != nil {
 		env.DisplayToConsole(true, "Downloading: %s\n", downloadUrl)
@@ -75,7 +82,13 @@ func DownloadViaMaven(downloadUrl string, env *Environment) (string, error) {
 	defer utils.Close(f)
 	//cache was readable, so validate
 	if err == nil {
-		h := sha1.New()
+		var h hash.Hash
+		if algorithm == FileHashSHA1 {
+			h = sha1.New()
+		} else if algorithm == FileHashSHA256 {
+			h = sha256.New()
+		}
+
 		if _, err := io.Copy(h, f); err != nil {
 			log.Fatal(err)
 		}
@@ -83,22 +96,27 @@ func DownloadViaMaven(downloadUrl string, env *Environment) (string, error) {
 
 		actualHash := fmt.Sprintf("%x", h.Sum(nil))
 
-		logging.Info.Printf("Downloading hash from %s", sha1Url)
-		response, err := HttpGet(sha1Url)
-		defer utils.CloseResponse(response)
-		if err != nil {
-			useCache = false
-		} else {
-			data := make([]byte, 40)
-			_, err := response.Body.Read(data)
-			expectedHash := string(data)
-
+		if strings.HasPrefix(expectedHash, "https://") || strings.HasPrefix(expectedHash, "http://") {
+			logging.Info.Printf("Downloading hash from %s", expectedHash)
+			response, err := HttpGet(expectedHash)
+			defer utils.CloseResponse(response)
 			if err != nil {
 				useCache = false
-			} else if expectedHash != actualHash {
-				logging.Info.Printf("Cache expected %s but was actually %s", expectedHash, actualHash)
-				useCache = false
+			} else {
+				data := make([]byte, 40)
+				_, err := response.Body.Read(data)
+				expectedHash = string(data)
+
+				if err != nil {
+					logging.Info.Printf("Failed downloading hash, not using cache")
+					useCache = false
+				}
 			}
+		}
+		
+		if expectedHash != actualHash {
+			logging.Info.Printf("Cache expected %s but was actually %s", expectedHash, actualHash)
+			useCache = false
 		}
 
 		if useCache {
@@ -106,9 +124,8 @@ func DownloadViaMaven(downloadUrl string, env *Environment) (string, error) {
 				logging.Info.Printf("Using cached copy of file: %s\n", downloadUrl)
 			}
 		}
-	} else if !os.IsNotExist(err) {
-		logging.Info.Printf("Cached file is not readable, will download (%s)", localPath)
 	} else {
+		logging.Info.Printf("Cached file is not readable, will download (%s)", localPath)
 		useCache = false
 	}
 
@@ -122,4 +139,8 @@ func DownloadViaMaven(downloadUrl string, env *Environment) (string, error) {
 	} else {
 		return "", err
 	}
+}
+
+func DownloadViaMaven(downloadUrl string, env *Environment) (string, error) {
+	return FileFromCacheOrDownload(downloadUrl, downloadUrl + ".sha1", FileHashSHA1, env)
 }

--- a/download.go
+++ b/download.go
@@ -1,15 +1,12 @@
 package pufferpanel
 
 import (
-	"crypto/sha1"
-	"crypto/sha256"
+	"crypto"
 	"fmt"
 	"github.com/pufferpanel/pufferpanel/v3/config"
 	"github.com/pufferpanel/pufferpanel/v3/logging"
 	"github.com/pufferpanel/pufferpanel/v3/utils"
-	"hash"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,88 +56,123 @@ func DownloadFileToCache(url, fileName string) error {
 	return err
 }
 
-type FileHash int
-
-const (
-	FileHashSHA1 = iota
-	FileHashSHA256
-)
-
-func FileFromCacheOrDownload(downloadUrl, expectedHash string, algorithm FileHash, env *Environment) (string, error) {
-	localPath := filepath.Join(config.CacheFolder.Value(), strings.TrimPrefix(strings.TrimPrefix(downloadUrl, "http://"), "https://"))
-
-	if os.PathSeparator != '/' {
-		localPath = strings.Replace(localPath, "/", string(os.PathSeparator), -1)
+func downloadFile(url string) (io.ReadCloser, error) {
+	logging.Info.Printf("Downloading: %s", url)
+	response, err := HttpGet(url)
+	if err != nil {
+		return nil, err
 	}
+	return response.Body, err
+}
 
+func cacheFile(downloadUrl, localPath string) (io.ReadCloser, error) {
+	dl, err := downloadFile(downloadUrl)
+	if err != nil {
+		utils.Close(dl)
+		return nil, err
+	}
+	parent := filepath.Dir(localPath)
+	err = os.MkdirAll(parent, 0755)
+	if err != nil && !os.IsExist(err) {
+		logging.Info.Printf("Failed directories in cache: %s", err)
+		return dl, nil
+	}
+	f, err := os.Create(localPath)
+	if err != nil {
+		utils.Close(f)
+		logging.Info.Printf("Failed creating file in cache: %s", err)
+		return dl, nil
+	}
+	_, err = io.Copy(f, dl)
+	utils.Close(dl)
+	if err != nil {
+		// failed actually writing to the successfully created file
+		utils.Close(f)
+		return nil, err
+	}
+	err = f.Sync()
+	if err != nil {
+		return nil, err
+	}
+	_, err = f.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func Download(downloadUrl, hash string, algorithm crypto.Hash, cache bool, env *Environment) (io.ReadCloser, error) {
 	if env != nil {
 		env.DisplayToConsole(true, "Downloading: %s\n", downloadUrl)
 	}
 
-	useCache := true
-	f, err := os.Open(localPath)
-	defer utils.Close(f)
-	//cache was readable, so validate
-	if err == nil {
-		var h hash.Hash
-		if algorithm == FileHashSHA1 {
-			h = sha1.New()
-		} else if algorithm == FileHashSHA256 {
-			h = sha256.New()
+	if !cache {
+		// don't interact with cache, directly return download response
+		return downloadFile(downloadUrl)
+	} else {
+		// caching allowed
+		localPath := filepath.Join(config.CacheFolder.Value(), strings.TrimPrefix(strings.TrimPrefix(downloadUrl, "http://"), "https://"))
+
+		if os.PathSeparator != '/' {
+			localPath = strings.Replace(localPath, "/", string(os.PathSeparator), -1)
 		}
 
+		// try to open existing cached file
+		f, err := os.Open(localPath)
+		if os.IsNotExist(err) {
+			// cache miss, need to download
+			return cacheFile(downloadUrl, localPath)
+		} else if err != nil {
+			logging.Info.Printf("Failed opening cached file despite it existing: %s", err)
+			return downloadFile(downloadUrl)
+		}
+
+		h := algorithm.New()
 		if _, err := io.Copy(h, f); err != nil {
-			log.Fatal(err)
+			utils.Close(f)
+			logging.Info.Printf("Cached file is not readable, will download (%s)", localPath)
+			return downloadFile(downloadUrl)
 		}
-		utils.Close(f)
-
 		actualHash := fmt.Sprintf("%x", h.Sum(nil))
-
-		if strings.HasPrefix(expectedHash, "https://") || strings.HasPrefix(expectedHash, "http://") {
-			logging.Info.Printf("Downloading hash from %s", expectedHash)
-			response, err := HttpGet(expectedHash)
-			defer utils.CloseResponse(response)
-			if err != nil {
-				useCache = false
-			} else {
-				data := make([]byte, 40)
-				_, err := response.Body.Read(data)
-				expectedHash = string(data)
-
-				if err != nil {
-					logging.Info.Printf("Failed downloading hash, not using cache")
-					useCache = false
-				}
-			}
+		_, err = f.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, err
 		}
-		
-		if expectedHash != actualHash {
-			logging.Info.Printf("Cache expected %s but was actually %s", expectedHash, actualHash)
-			useCache = false
+		if hash == actualHash {
+			logging.Info.Printf("Using cached copy of file: %s\n", downloadUrl)
+			return f, nil
+		} else {
+			logging.Info.Printf("Cache expected %s but was actually %s, downloading new version and caching to %s", hash, actualHash, localPath)
+			utils.Close(f)
+			return cacheFile(downloadUrl, localPath)
 		}
-
-		if useCache {
-			if env != nil {
-				logging.Info.Printf("Using cached copy of file: %s\n", downloadUrl)
-			}
-		}
-	} else {
-		logging.Info.Printf("Cached file is not readable, will download (%s)", localPath)
-		useCache = false
-	}
-
-	//if we can't use cache, redownload it to the cache
-	if !useCache {
-		logging.Info.Printf("Downloading new version and caching to %s", localPath)
-		err = DownloadFileToCache(downloadUrl, localPath)
-	}
-	if err == nil {
-		return localPath, err
-	} else {
-		return "", err
 	}
 }
 
-func DownloadViaMaven(downloadUrl string, env *Environment) (string, error) {
-	return FileFromCacheOrDownload(downloadUrl, downloadUrl + ".sha1", FileHashSHA1, env)
+func DownloadHash(hashUrl string, algorithm crypto.Hash) (string, error) {
+	logging.Info.Printf("Downloading hash from %s", hashUrl)
+	response, err := HttpGet(hashUrl)
+	defer utils.CloseResponse(response)
+	if err != nil {
+		return "", err
+	} else {
+		data := make([]byte, algorithm.Size() * 2)
+		_, err := response.Body.Read(data)
+		if err != nil {
+			return "", err
+		}
+
+		return string(data), nil
+	}
+}
+
+func DownloadViaMaven(downloadUrl string, env *Environment) (io.ReadCloser, error) {
+	hashUrl := downloadUrl + ".sha1"
+	expectedHash, err := DownloadHash(hashUrl, crypto.SHA1)
+	if err != nil {
+		logging.Info.Printf("Failed downloading hash, not using cache")
+		return Download(downloadUrl, "", crypto.SHA1, false, env)
+	}
+
+	return Download(downloadUrl, expectedHash, crypto.SHA1, true, env)
 }

--- a/files/files.go
+++ b/files/files.go
@@ -27,7 +27,7 @@ func CopyFile(src, dest string) error {
 	return err
 }
 
-func WriteFile(src io.ReadCloser, dest string) error {
+func WriteFile(src io.Reader, dest string) error {
 	destination, err := os.Create(dest)
 	if err != nil {
 		return err

--- a/files/files.go
+++ b/files/files.go
@@ -26,3 +26,13 @@ func CopyFile(src, dest string) error {
 	_, err = io.Copy(destination, source)
 	return err
 }
+
+func WriteFile(src io.ReadCloser, dest string) error {
+	destination, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer utils.Close(destination)
+	_, err = io.Copy(destination, src)
+	return err
+}

--- a/operations/curseforge/curseforge.go
+++ b/operations/curseforge/curseforge.go
@@ -184,12 +184,13 @@ func (c CurseForge) Run(args pufferpanel.RunOperatorArgs) pufferpanel.OperationR
 				forgeUrl := replaceTokens(ForgeInstallerUrl, data)
 				forgeInstaller := replaceTokens(ForgeInstallerName, data)
 
-				jarFile, err = pufferpanel.DownloadViaMaven(forgeUrl, env)
+				dl, err := pufferpanel.DownloadViaMaven(forgeUrl, env)
+				defer utils.Close(dl)
 				if err != nil {
 					return pufferpanel.OperationResult{Error: err}
 				}
 				//copy to server
-				err = files.CopyFile(jarFile, filepath.Join(env.GetRootDirectory(), forgeInstaller))
+				err = files.WriteFile(dl, filepath.Join(env.GetRootDirectory(), forgeInstaller))
 				if err != nil {
 					return pufferpanel.OperationResult{Error: err}
 				}

--- a/operations/fabricdl/fabricdl.go
+++ b/operations/fabricdl/fabricdl.go
@@ -39,11 +39,12 @@ func (f *Fabricdl) Run(args pufferpanel.RunOperatorArgs) pufferpanel.OperationRe
 	}
 
 	file, err := pufferpanel.DownloadViaMaven(metadata[0].Url, env)
+	defer utils.Close(file)
 	if err != nil {
 		return pufferpanel.OperationResult{Error: err}
 	}
 
-	err = files.CopyFile(file, path.Join(env.GetRootDirectory(), "fabric-installer.jar"))
+	err = files.WriteFile(file, path.Join(env.GetRootDirectory(), "fabric-installer.jar"))
 	if err != nil {
 		return pufferpanel.OperationResult{Error: err}
 	}

--- a/operations/forgedl/forgedl.go
+++ b/operations/forgedl/forgedl.go
@@ -50,12 +50,13 @@ func (op ForgeDl) Run(args pufferpanel.RunOperatorArgs) pufferpanel.OperationRes
 	jarDownload := strings.Replace(InstallerUrl, "${version}", op.Version, -1)
 
 	localFile, err := pufferpanel.DownloadViaMaven(jarDownload, env)
+	defer utils.Close(localFile)
 	if err != nil {
 		return pufferpanel.OperationResult{Error: err}
 	}
 
 	//copy from the cache
-	err = files.CopyFile(localFile, path.Join(env.GetRootDirectory(), op.Filename))
+	err = files.WriteFile(localFile, path.Join(env.GetRootDirectory(), op.Filename))
 	if err != nil {
 		return pufferpanel.OperationResult{Error: err}
 	}

--- a/operations/neoforgedl/neoforgedl.go
+++ b/operations/neoforgedl/neoforgedl.go
@@ -35,12 +35,13 @@ func (op NeoforgeDL) Run(args pufferpanel.RunOperatorArgs) pufferpanel.Operation
 	jarDownload := strings.Replace(InstallerUrl, "${version}", op.Version, -1)
 
 	localFile, err := pufferpanel.DownloadViaMaven(jarDownload, env)
+	defer utils.Close(localFile)
 	if err != nil {
 		return pufferpanel.OperationResult{Error: err}
 	}
 
 	//copy from the cache
-	err = files.CopyFile(localFile, path.Join(env.GetRootDirectory(), op.Filename))
+	err = files.WriteFile(localFile, path.Join(env.GetRootDirectory(), op.Filename))
 	if err != nil {
 		return pufferpanel.OperationResult{Error: err}
 	}

--- a/operations/paperdl/factory.go
+++ b/operations/paperdl/factory.go
@@ -3,7 +3,6 @@ package paperdl
 import (
 	"errors"
 	"github.com/pufferpanel/pufferpanel/v3"
-	"github.com/pufferpanel/pufferpanel/v3/logging"
 	"github.com/spf13/cast"
 )
 
@@ -12,7 +11,6 @@ type OperationFactory struct {
 }
 
 func (of OperationFactory) Create(op pufferpanel.CreateOperation) (pufferpanel.Operation, error) {
-	logging.Debug.Printf("create entered")
 	minecraftVersion := cast.ToString(op.OperationArgs["minecraftVersion"])
 	build := cast.ToString(op.OperationArgs["build"])
 	filename := cast.ToString(op.OperationArgs["target"])
@@ -25,7 +23,6 @@ func (of OperationFactory) Create(op pufferpanel.CreateOperation) (pufferpanel.O
 		return nil, errors.New("missing build")
 	}
 
-	logging.Debug.Printf("create done")
 	return PaperDl{MinecraftVersion: minecraftVersion, Build: build, Filename: filename}, nil
 }
 

--- a/operations/paperdl/factory.go
+++ b/operations/paperdl/factory.go
@@ -1,0 +1,36 @@
+package paperdl
+
+import (
+	"errors"
+	"github.com/pufferpanel/pufferpanel/v3"
+	"github.com/pufferpanel/pufferpanel/v3/logging"
+	"github.com/spf13/cast"
+)
+
+type OperationFactory struct {
+	pufferpanel.OperationFactory
+}
+
+func (of OperationFactory) Create(op pufferpanel.CreateOperation) (pufferpanel.Operation, error) {
+	logging.Debug.Printf("create entered")
+	minecraftVersion := cast.ToString(op.OperationArgs["minecraftVersion"])
+	build := cast.ToString(op.OperationArgs["build"])
+	filename := cast.ToString(op.OperationArgs["target"])
+
+	if minecraftVersion == "" {
+		return nil, errors.New("missing minecraftVersion")
+	}
+
+	if build == "" {
+		return nil, errors.New("missing build")
+	}
+
+	logging.Debug.Printf("create done")
+	return PaperDl{MinecraftVersion: minecraftVersion, Build: build, Filename: filename}, nil
+}
+
+func (of OperationFactory) Key() string {
+	return "paperdl"
+}
+
+var Factory OperationFactory

--- a/operations/paperdl/paperdl.go
+++ b/operations/paperdl/paperdl.go
@@ -1,6 +1,7 @@
 package paperdl
 
 import (
+	"crypto"
 	"encoding/json"
 	"errors"
 	"github.com/hashicorp/go-version"
@@ -41,14 +42,13 @@ func (op PaperDl) Run(args pufferpanel.RunOperatorArgs) pufferpanel.OperationRes
 		return pufferpanel.OperationResult{Error: err}
 	}
 
-	localFile, err := pufferpanel.FileFromCacheOrDownload(dlUrl, hash, pufferpanel.FileHashSHA256, env)
+	dl, err := pufferpanel.Download(dlUrl, hash, crypto.SHA256, true, env)
+	defer utils.Close(dl)
 	if err != nil {
 		return pufferpanel.OperationResult{Error: err}
 	}
 
-
-	//copy from the cache
-	err = files.CopyFile(localFile, path.Join(env.GetRootDirectory(), op.Filename))
+	err = files.WriteFile(dl, path.Join(env.GetRootDirectory(), op.Filename))
 	if err != nil {
 		return pufferpanel.OperationResult{Error: err}
 	}
@@ -85,7 +85,7 @@ func getLatestMCVersion() (string, error) {
 	for _, v := range versions.Versions {
 		if ver, err := version.NewVersion(v.VersionInfo.Id); err == nil && latest.LessThan(ver) {
 			latest = ver
-		} else {
+		} else if err != nil {
 			logging.Info.Printf("failed to parse version '%s', %s", v, err)
 		}
 	}
@@ -105,7 +105,7 @@ func (op PaperDl) getDownloadUrlAndHash(env *pufferpanel.Environment) (string, s
 		URL: path,
 		Header: http.Header{},
 	}
-	request.Header.Add("user-agent", UserAgent)
+	request.Header.Add("User-Agent", UserAgent)
 
 	response, err := pufferpanel.Http().Do(request)
 	defer utils.CloseResponse(response)
@@ -124,7 +124,7 @@ func (op PaperDl) getDownloadUrlAndHash(env *pufferpanel.Environment) (string, s
 		return "", "", err
 	}
 
-	return build.Dowloads.Server.Url, build.Dowloads.Server.Checksums.Sha256, nil
+	return build.Downloads.Server.Url, build.Downloads.Server.Checksums.Sha256, nil
 }
 
 type PaperVersionInfo struct {
@@ -153,5 +153,5 @@ type PaperDownload struct {
 }
 
 type PaperBuild struct {
-	Dowloads PaperDownload `json:"downloads"`
+	Downloads PaperDownload `json:"downloads"`
 }

--- a/operations/paperdl/paperdl.go
+++ b/operations/paperdl/paperdl.go
@@ -1,0 +1,157 @@
+package paperdl
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/hashicorp/go-version"
+	"github.com/pufferpanel/pufferpanel/v3"
+	"github.com/pufferpanel/pufferpanel/v3/files"
+	"github.com/pufferpanel/pufferpanel/v3/logging"
+	"github.com/pufferpanel/pufferpanel/v3/utils"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
+
+const VersionsUrl = "https://fill.papermc.io/v3/projects/paper/versions"
+const BuildUrl = "https://fill.papermc.io/v3/projects/paper/versions/${mcVersion}/builds/${build}"
+var UserAgent = pufferpanel.Display + " https://github.com/pufferpanel/pufferpanel"
+
+type PaperDl struct {
+	MinecraftVersion string
+	Build            string
+	Filename         string
+}
+
+func (op PaperDl) Run(args pufferpanel.RunOperatorArgs) pufferpanel.OperationResult {
+	env := args.Environment
+
+	if op.MinecraftVersion == "latest" {
+		logging.Info.Printf("PaperDL got Minecraft version 'latest', looking up latest version supported by Paper")
+		mcVersion, err := getLatestMCVersion()
+		if err != nil {
+			return pufferpanel.OperationResult{Error: err}
+		}
+		op.MinecraftVersion = mcVersion
+	}
+
+	dlUrl, hash, err := op.getDownloadUrlAndHash(env)
+	if err != nil {
+		return pufferpanel.OperationResult{Error: err}
+	}
+
+	localFile, err := pufferpanel.FileFromCacheOrDownload(dlUrl, hash, pufferpanel.FileHashSHA256, env)
+	if err != nil {
+		return pufferpanel.OperationResult{Error: err}
+	}
+
+
+	//copy from the cache
+	err = files.CopyFile(localFile, path.Join(env.GetRootDirectory(), op.Filename))
+	if err != nil {
+		return pufferpanel.OperationResult{Error: err}
+	}
+
+	return pufferpanel.OperationResult{Error: nil}
+}
+
+func getLatestMCVersion() (string, error) {
+	path, err := url.Parse(VersionsUrl)
+	if err != nil {
+		return "", err
+	}
+
+	request := &http.Request{
+		Method: "GET",
+		URL: path,
+		Header: http.Header{},
+	}
+	request.Header.Add("user-agent", UserAgent)
+
+	response, err := pufferpanel.Http().Do(request)
+	defer utils.CloseResponse(response)
+	if err != nil {
+		return "", err
+	}
+
+	var versions PaperVersionsResponse
+	err = json.NewDecoder(response.Body).Decode(&versions)
+	if err != nil {
+		return "", err
+	}
+
+	latest, _ := version.NewVersion("0.0")
+	for _, v := range versions.Versions {
+		if ver, err := version.NewVersion(v.VersionInfo.Id); err == nil && latest.LessThan(ver) {
+			latest = ver
+		} else {
+			logging.Info.Printf("failed to parse version '%s', %s", v, err)
+		}
+	}
+
+	logging.Info.Printf("Latest Minecraft version supported by Paper is %s", latest.Original())
+	return latest.Original(), nil
+}
+
+func (op PaperDl) getDownloadUrlAndHash(env *pufferpanel.Environment) (string, string, error) {
+	path, err := url.Parse(strings.Replace(strings.Replace(BuildUrl, "${mcVersion}", op.MinecraftVersion, -1), "${build}", op.Build, -1))
+	if err != nil {
+		return "", "", err
+	}
+
+	request := &http.Request{
+		Method: "GET",
+		URL: path,
+		Header: http.Header{},
+	}
+	request.Header.Add("user-agent", UserAgent)
+
+	response, err := pufferpanel.Http().Do(request)
+	defer utils.CloseResponse(response)
+	if err != nil {
+		return "", "", err
+	}
+
+	if response.StatusCode == 404 {
+		env.DisplayToConsole(true, "Invalid Minecraft version or Paper build\n")
+		return "", "", errors.New("Invalid minecraft version or paper build")
+	}
+
+	var build PaperBuild
+	err = json.NewDecoder(response.Body).Decode(&build)
+	if err != nil {
+		return "", "", err
+	}
+
+	return build.Dowloads.Server.Url, build.Dowloads.Server.Checksums.Sha256, nil
+}
+
+type PaperVersionInfo struct {
+	Id string `json:"id"`
+}
+
+type PaperVersion struct {
+	VersionInfo PaperVersionInfo `json:"version"`
+}
+
+type PaperVersionsResponse struct {
+	Versions []PaperVersion `json:"versions"`
+}
+
+type PaperChecksums struct {
+	Sha256 string `json:"sha256"`
+}
+
+type PaperServer struct {
+	Checksums PaperChecksums `json:"checksums"`
+	Url       string         `json:"url"`
+}
+
+type PaperDownload struct {
+	Server PaperServer `json:"server:default"`
+}
+
+type PaperBuild struct {
+	Dowloads PaperDownload `json:"downloads"`
+}

--- a/operations/spongedl/spongedl.go
+++ b/operations/spongedl/spongedl.go
@@ -106,12 +106,13 @@ func (op SpongeDl) Run(args pufferpanel.RunOperatorArgs) pufferpanel.OperationRe
 			}
 
 			file, err := pufferpanel.DownloadViaMaven(url, env)
+			defer utils.Close(file)
 			if err != nil {
 				return pufferpanel.OperationResult{Error: err}
 			}
 
 			//going to stick the spongeforge rename in, to assist with those modpacks
-			err = files.CopyFile(file, path.Join(env.GetRootDirectory(), "mods", "_aspongeforge.jar"))
+			err = files.WriteFile(file, path.Join(env.GetRootDirectory(), "mods", "_aspongeforge.jar"))
 			if err != nil {
 				return pufferpanel.OperationResult{Error: err}
 			}
@@ -119,11 +120,12 @@ func (op SpongeDl) Run(args pufferpanel.RunOperatorArgs) pufferpanel.OperationRe
 	case "spongevanilla":
 		{
 			file, err := pufferpanel.DownloadViaMaven(url, env)
+			defer utils.Close(file)
 			if err != nil {
 				return pufferpanel.OperationResult{Error: err}
 			}
 
-			err = files.CopyFile(file, path.Join(env.GetRootDirectory(), "server.jar"))
+			err = files.WriteFile(file, path.Join(env.GetRootDirectory(), "server.jar"))
 			if err != nil {
 				return pufferpanel.OperationResult{Error: err}
 			}

--- a/servers/operation_process.go
+++ b/servers/operation_process.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pufferpanel/pufferpanel/v3/operations/mojangdl"
 	"github.com/pufferpanel/pufferpanel/v3/operations/move"
 	"github.com/pufferpanel/pufferpanel/v3/operations/neoforgedl"
+	"github.com/pufferpanel/pufferpanel/v3/operations/paperdl"
 	"github.com/pufferpanel/pufferpanel/v3/operations/resolveforgeversion"
 	"github.com/pufferpanel/pufferpanel/v3/operations/resolveneoforgeversion"
 	"github.com/pufferpanel/pufferpanel/v3/operations/sleep"
@@ -47,6 +48,7 @@ var factories = []pufferpanel.OperationFactory{
 	mojangdl.Factory,
 	move.Factory,
 	neoforgedl.Factory,
+	paperdl.Factory,
 	resolveforgeversion.Factory,
 	resolveneoforgeversion.Factory,
 	sleep.Factory,


### PR DESCRIPTION
PaperMC has changed their download URLs to include random hashes, therefore we now need to talk to their API to get the download link. As [stated here](https://docs.papermc.io/misc/downloads-api/) they require setting the user agent header to include project name and a contact URL or email, so I decided to use the already existing `pufferpanel.Display` variable followed by the repository URL as the user agent string.  
This implementation also resolves the latest PaperMC supported Minecraft version if that is set to `latest` while the PaperMC API allows using `latest` for the build number to get the most recent build. Downloads will also be cached and validated by checksum if pulled from cache.