### PR TITLE
Add bash to runtime image so host-environment servers can start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN xx-verify /pufferpanel/pufferpanel
 FROM alpine
 
 EXPOSE 8080 5657
+RUN apk add --no-cache bash
 RUN mkdir -p /etc/pufferpanel && \
     mkdir -p /var/lib/pufferpanel /var/lib/pufferpanel/servers /var/lib/pufferpanel/binaries /var/lib/pufferpanel/cache && \
     mkdir -p /var/log/pufferpanel


### PR DESCRIPTION
Fixes #1485.

## Summary

The v3 daemon's tty environment hardcodes bash and execs `bash -c …`, but the runtime image is `FROM alpine` without bash installed, so every host/tty server fails to start on the official `pufferpanel/pufferpanel:3.0.7` image:

```
exec: "bash": executable file not found in $PATH
```

This adds `RUN apk add --no-cache bash` to the final stage of the Dockerfile so the daemon's existing code path works.

## Why this fix

The daemon uses bash unconditionally:

- `servers/tty/tty.go:350` — `const Shell = "bash"`
- line 360 — `exec.Command(Shell, "-c", …)` (disable-unshare path)
- lines 426, 428 — `exec.Command(Shell, "-c", …)` (unshare path)

I noticed commit 4ae68d0 explicitly keeps bash out of the runtime image ("This isn't included in the resulting image, but is used for our tests"), so this may be intentional — but the daemon still requires bash on every host-environment start, which makes the official image non-functional for the host environment as shipped.

The alternative — falling back to `sh` in `tty.go` when bash is missing — would silently change the shell every host-environment server runs under, potentially breaking user templates that rely on bashisms. Adding bash to the image is one line and zero behavior change.

Cost: ~1.7 MB and one apk layer.

## Test plan

I have **not** built the full image locally yet (the multi-stage build pulls a large Go/Node toolchain and I didn't want to gate the PR on that). What I have verified:

- [x] The change is a single line in the runtime stage; `apk add --no-cache bash` is the standard Alpine bash install.
- [x] On the unmodified `pufferpanel/pufferpanel:3.0.7` image, `docker run --rm --entrypoint sh pufferpanel/pufferpanel:3.0.7 -c 'which bash || echo missing'` reports `missing`, confirming the regression source.
- [ ] Maintainer/CI: full image build + host-environment server start.

Happy to do a full local build and report back if you'd like, or to adjust to a code-side fix or a different approach (e.g. documenting host environment as requiring a derived image on the official base).