### PR TITLE
fix: preserve group membership when renaming a template variable

### DIFF
--- a/client/frontend/src/components/template/Variables.vue
+++ b/client/frontend/src/components/template/Variables.vue
@@ -120,6 +120,13 @@ function confirmEdit() {
   editOpen.value = false
   if (edit.value.oldName && edit.value.oldName !== edit.value.name) {
     delete template.value.data[edit.value.oldName]
+    if (Array.isArray(template.value.groups)) {
+      template.value.groups = template.value.groups.map(group => {
+        const index = group.variables.indexOf(edit.value.oldName)
+        if (index !== -1) group.variables[index] = edit.value.name
+        return group
+      })
+    }
   }
   const name = edit.value.name
   delete edit.value.name


### PR DESCRIPTION
## Summary

Fixes #1471.

Renaming an existing template variable through the template editor's Variables tab deletes the old key from `template.data`, but never updates the variable's entry in its group's `variables` array. The group keeps referencing the variable by its old name, so the next render does `template.data[oldName].display`, which is now `undefined`, and throws inside the render function. That crash blanks out the whole variables tab, matching the reported behavior and its documented workaround (manually fixing the name under the raw JSON tab).

## Fix

In `confirmEdit()`, when an existing variable is renamed, also swap the old name for the new name inside any group's `variables` array that references it.

## Test plan

- [x] `eslint` on the changed file (clean)
- [x] `yarn workspaces run build` (clean build)
- [x] Reproduced the exact repro steps from #1471 against a standalone copy of the before/after `confirmEdit` logic: the old code throws `Cannot read properties of undefined (reading 'display')` on rename, the fixed code renders correctly.