### PR TITLE
DEB: Execute DB migration as pufferpanel user

### DIFF
--- a/systemd/scripts/postinstall.sh
+++ b/systemd/scripts/postinstall.sh
@@ -7,7 +7,7 @@ if [ ! -f "/var/lib/pufferpanel/database.db" ]; then
   touch /var/lib/pufferpanel/database.db
 fi
 
-pufferpanel --config=/etc/pufferpanel/config.json db upgrade
+runuser -u pufferpanel pufferpanel --config=/etc/pufferpanel/config.json db upgrade
 exitCode=$?
 [ $exitCode -eq 0 ] || [ $exitCode -eq 9 ] || exit $exitCode
 

--- a/systemd/scripts/postupgrade.sh
+++ b/systemd/scripts/postupgrade.sh
@@ -11,7 +11,7 @@ wasRunning=$?
 
 systemctl stop pufferpanel
 
-pufferpanel --config=/etc/pufferpanel/config.json db upgrade
+runuser -u pufferpanel pufferpanel --config=/etc/pufferpanel/config.json db upgrade
 exitCode=$?
 [ $exitCode -eq 0 ] || [ $exitCode -eq 9 ] || exit $exitCode
 


### PR DESCRIPTION
Changes the debian package's scripts to run the `pufferpanel` executable as the pufferpanel user like the systemd service does.
This allows the database migrations to connect to the database successfully, if one is using e.g. PostgreSQL with peer authentication over a UNIX socket.