### PR TITLE
fixed stale folder overwrite error when starting docker container after crash

### DIFF
--- a/servers/docker/container_mount_source.go
+++ b/servers/docker/container_mount_source.go
@@ -27,7 +27,7 @@ func InitContainerMountSource() (err error) {
 	}
 
 	path := filepath.Join(os.TempDir(), "puffer-cid")
-	err = os.Mkdir(path, 0755)
+	err = os.MkdirAll(path, 0755)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Resolves #1497

Added `os.RemoveAll()` before creating the temp folder which allows the folder creation to succeed even if the folder was already there before.

I think it would be better if the whole creation process was put in a `if folder does not exists` statement, but i noticed how clean the code is and i would rather keep it that way.